### PR TITLE
Fix for Useless assignment to local variable

### DIFF
--- a/src/plugins/rehype-rewrite-links.mjs
+++ b/src/plugins/rehype-rewrite-links.mjs
@@ -22,7 +22,7 @@ export function rehypeRewriteLinks() {
 
     // Determine the base URL based on file location
     let basePath = '';
-    let lang = 'ja';
+    let lang;
 
     // Extract language and context from file path
     // e.g., /path/to/player/specs/ja/display-object.md


### PR DESCRIPTION
In general, the way to fix this kind of issue is to remove unused initializations so that variables are either initialized only when actually needed or are not declared at all if unused. This simplifies the code and avoids confusion about default behavior that doesn’t actually occur.

For this specific case in `src/plugins/rehype-rewrite-links.mjs`, we should keep the `lang` variable, because it is used to build `basePath`, but we should remove the initial value `'ja'` since it is never read. The best minimal change is to change `let lang = 'ja';` to `let lang;`. This keeps the rest of the logic intact: `lang` is only used after being set in either the `playerMatch` or `frameworkMatch` branches, and if neither match, we return early before using it. No additional imports, methods, or definitions are required.

The line to change is line 25 in the provided snippet, within `export function rehypeRewriteLinks()`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._